### PR TITLE
Make "Going to NICAR?" label clickable

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -53,7 +53,7 @@
               <input id="name-new" type="text" placeholder="Name" value=""></input>
               <div class="checkbox cf">
                 <input id="going-to-nicar" type="checkbox"></input>
-                <label>Going to NICAR?</label>
+                <label for="going-to-nicar">Going to NICAR?</label>
               </div>
               <button id="submit-new">Create</button>
             </div>


### PR DESCRIPTION
The checkbox is tiny enough that it's hard to click. Adding the `for`
attribute to the associated `<label>` is semantically nice and lets a
user click the label to toggle the checkbox.