### PR TITLE
Make clicking "Going to NICAR?" check the input box

### DIFF
--- a/templates/base.html
+++ b/templates/base.html
@@ -53,7 +53,7 @@
               <input id="name-new" type="text" placeholder="Name" value=""></input>
               <div class="checkbox cf">
                 <input id="going-to-nicar" type="checkbox"></input>
-                <label>Going to NICAR?</label>
+                <label for="going-to-nicar">Going to NICAR?</label>
               </div>
               <button id="submit-new">Create</button>
             </div>


### PR DESCRIPTION
The `<input>` checkbox for the "Going to NICAR?" prompt is pretty tiny, and the `<label>` for it doesn't know it belongs to that input!

This pull adds the `for=` attribute to the label so clicks on the text also check the checkbox.