### PR TITLE
Moving user creation/login to POST

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ The core logic of the site is handled via a series of Flask routes that recieve 
 
 This route handles two behaviors.
 
-* **Register a new user**: If `email`, `password` and `name` are sent as URL parameters, the route will attempt to register this user. If an existing user has this email address, the user will be logged in. If there is no existing user with this email address, the user will be registered and a message will be sent returning the new user's `_id`, a `success` flag and an `action` key with the value `register`.
+* **Register a new user**: If `email`, `password` and `name` are sent as POST parameters, the route will attempt to register this user. If an existing user has this email address, the user will be logged in. If there is no existing user with this email address, the user will be registered and a message will be sent returning the new user's `_id`, a `success` flag and an `action` key with the value `register`.
 ```json
 {
     "_id": "97984267-ab75-46c4-b113-016a5555e92b",
@@ -217,7 +217,7 @@ This route handles two behaviors.
 }
 ```
 
-* **Login an existing user**: If only an `email` and `password` URL parameter are sent, the route will attempt to login the specified user. Success will return a user's `_id`, a `success` flag and an `action` key with the value `login`. It will also return a cookie-friendly pipe-delimited list of session `_id`'s as `votes`. Failure will return an error message with `success` false and a message that a matching user cannot be found.
+* **Login an existing user**: If only an `email` and `password` POST parameter are sent, the route will attempt to login the specified user. Success will return a user's `_id`, a `success` flag and an `action` key with the value `login`. It will also return a cookie-friendly pipe-delimited list of session `_id`'s as `votes`. Failure will return an error message with `success` false and a message that a matching user cannot be found.
 ```json
 {
     "action": "login",

--- a/app.py
+++ b/app.py
@@ -45,8 +45,8 @@ def index():
 def static_proxy(path):
   return app.send_static_file(path)
 
-@app.route('/api/dashboard/')
-def dashboard(methods=['GET']):
+@app.route('/api/dashboard/', methods=['GET'])
+def dashboard():
     sessions = utils.connect('session').find({})
     payload = []
 
@@ -72,19 +72,19 @@ def dashboard(methods=['GET']):
 
     return render_template('dashboard.html', sessions=payload, VOTING=True)
 
-@app.route('/api/user/action/')
-def user_action(methods=['GET']):
+@app.route('/api/user/action/', methods=['POST'])
+def user_action():
     from flask import request
-    email = request.args.get('email', None)
-    password = request.args.get('password', None)
+    email = request.form['email']
+    password = request.form['password']
 
     not_found = json.dumps({"success": False, "text": "Username or password is incorrect."})
 
     user = utils.connect('user').find_one({ "email": email })
 
     if not user:
-        name = request.args.get('name', None)
-        fingerprint = request.args.get('fp', None)
+        name = request.form['name']
+        fingerprint = request.form['fp']
 
         if not name or not fingerprint:
             return not_found
@@ -128,8 +128,8 @@ def session_action(methods=['GET']):
 
         return json.dumps({"success": True, "action": "create", "session": s['_id']})
 
-@app.route('/api/vote/action/')
-def vote_action(methods=['GET']):
+@app.route('/api/vote/action/', methods=['GET'])
+def vote_action():
     from flask import request
     session = request.args.get('session')
     user = request.args.get('user')
@@ -167,8 +167,8 @@ def vote_action(methods=['GET']):
 
     return error
 
-@app.route('/api/vote/')
-def api_vote(methods=['GET']):
+@app.route('/api/vote/', methods=['GET'])
+def api_vote():
     from flask import request
     _id = request.args.get('_id', None)
     if not _id:
@@ -176,8 +176,8 @@ def api_vote(methods=['GET']):
     vote = dict(utils.connect('vote').find_one({"_id": _id}))
     return json.dumps(vote)
 
-@app.route('/api/user/')
-def api_user(methods=['GET']):
+@app.route('/api/user/', methods=['GET'])
+def api_user():
     from flask import request
     _id = request.args.get('_id', None)
     if not _id:
@@ -187,8 +187,8 @@ def api_user(methods=['GET']):
         del user[x]
     return json.dumps(user)
 
-@app.route('/api/session/')
-def api_session(methods=['GET']):
+@app.route('/api/session/', methods=['GET'])
+def api_session():
     from flask import request
     _id = request.args.get('_id', None)
     if not _id:

--- a/app.py
+++ b/app.py
@@ -84,7 +84,7 @@ def user_action():
 
     if not user:
         name = request.form['name']
-        fingerprint = request.form['fp']
+        fingerprint = request.form['fingerprint']
 
         if not name or not fingerprint:
             return not_found

--- a/app.py
+++ b/app.py
@@ -84,7 +84,8 @@ def user_action(methods=['GET']):
 
     if not user:
         name = request.args.get('name', None)
-        fingerprint = request.args.get('fingerprint', None)
+        fingerprint = request.args.get('fp', None)
+
         if not name or not fingerprint:
             return not_found
 

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -146,7 +146,7 @@ $(function(){
     var user_login = function(register) {
         var url = loginHost + 'user/action/';
         var form = {
-            'fp': fingerprint
+            'fingerprint': fingerprint
         }
         if (register){
             form['email'] = $email.val();

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -145,24 +145,26 @@ $(function(){
 
     var user_login = function(register) {
         var url = loginHost + 'user/action/';
-
+        var form = {
+            'fp': fingerprint
+        }
         if (register){
-            url += '?email=' + $email.val();
-            url += '&password=' + $password.val();
-            url += '&fp=' + fingerprint;
-            url += '&name=' + $name.val();
+            form['email'] = $email.val();
+            form['password'] = $password.val();
+            form['name'] = $name.val();
         } else {
-            url += '?email=' + $emailExisting.val();
-            url += '&password=' + passwordExisting.val();
-            url += '&fp=' + fingerprint;
+            form['email'] = $emailExisting.val();
+            form['password'] = passwordExisting.val();
         }
 
         var checked = $('#going-to-nicar').is(":checked");
 
         if (!register || register && checked){
             $.ajax(url, {
+                method: 'POST',
+                data: form,
                 async: true,
-                cache: true,
+                cache: false,
                 crossDomain: false,
                 dataType: 'json',
                 jsonp: false,

--- a/templates/static/site.js
+++ b/templates/static/site.js
@@ -149,18 +149,17 @@ $(function(){
         if (register){
             url += '?email=' + $email.val();
             url += '&password=' + $password.val();
-            url += '&fingerprint=' + fingerprint;
+            url += '&fp=' + fingerprint;
             url += '&name=' + $name.val();
         } else {
             url += '?email=' + $emailExisting.val();
             url += '&password=' + passwordExisting.val();
-            url += '&fingerprint=' + fingerprint;
+            url += '&fp=' + fingerprint;
         }
 
         var checked = $('#going-to-nicar').is(":checked");
 
         if (!register || register && checked){
-
             $.ajax(url, {
                 async: true,
                 cache: true,


### PR DESCRIPTION
Had issues creating a password with a `#` in it, stumbled down some rabbit holes, changed user login/etc to use `POST` so it'd work all right.

Additional bonus: passwords won't be hanging out in the URL string.