### PR TITLE
Prevent overflowing content from stretching page

### DIFF
--- a/templates/static/site.css
+++ b/templates/static/site.css
@@ -135,6 +135,10 @@ div.session.unvoted .orange {
     font-size: 20px;
 }
 
+.content-box p {
+    overflow-x: auto;
+}
+
 p.author {
     font-size: 12px;
     color: #888;


### PR DESCRIPTION
Before:
<img width="315" alt="Screenshot 2020-02-14 at 21 19 19" src="https://user-images.githubusercontent.com/1442752/74580344-1c205080-4f71-11ea-96b6-e1139f435e77.png">

After:
<img width="325" alt="Screenshot 2020-02-14 at 21 26 24" src="https://user-images.githubusercontent.com/1442752/74580346-1cb8e700-4f71-11ea-8aee-88fb38551cac.png">
